### PR TITLE
Simplify Markdown to Word invisible character UI

### DIFF
--- a/Demo/Demos/MarkdownToWord/InvisibleUnicodeDemoGenerator.cs
+++ b/Demo/Demos/MarkdownToWord/InvisibleUnicodeDemoGenerator.cs
@@ -1,146 +1,42 @@
-﻿namespace Demo.Demos.MarkdownToWord;
+namespace Demo.Demos.MarkdownToWord;
 
-using System.Collections.Generic;
 using System.Text;
 
 public static class InvisibleUnicodeDemoGenerator
 {
     public static string BuildMarkdown()
     {
-        var inv = new Dictionary<char, (string Alias, string UnicodeName)>
-        {
-            ['\u200B'] = ("ZWSP", "ZERO WIDTH SPACE"),
-            ['\u200C'] = ("ZWNJ", "ZERO WIDTH NON-JOINER"),
-            ['\u200D'] = ("ZWJ", "ZERO WIDTH JOINER"),
-            ['\u2060'] = ("WJ", "WORD JOINER"),
-            ['\uFEFF'] = ("FEFF", "ZERO WIDTH NO-BREAK SPACE / BOM"),
-            ['\u00AD'] = ("SHY", "SOFT HYPHEN"),
-            ['\u00A0'] = ("NBSP", "NO-BREAK SPACE"),
-            ['\u200E'] = ("LRM", "LEFT-TO-RIGHT MARK"),
-            ['\u200F'] = ("RLM", "RIGHT-TO-LEFT MARK"),
-            ['\u2063'] = ("INVISIBLE SEPARATOR", "INVISIBLE SEPARATOR"),
-            ['\u2062'] = ("INVISIBLE TIMES", "INVISIBLE TIMES"),
-            ['\u2064'] = ("INVISIBLE PLUS", "INVISIBLE PLUS"),
-        };
-        var invSet = new HashSet<char>(inv.Keys);
+        const char control = '\u0001';
+        const char tab = '\t';
+        const char lineSeparator = '\u2028';
+        const char thinSpace = '\u2009';
+        const char nonBreakingSpace = '\u00A0';
+        const char zeroWidthSpace = '\u200B';
+        const char leftToRightMark = '\u200E';
+        const char softHyphen = '\u00AD';
+        const char invisibleSeparator = '\u2063';
+        const char variationSelector = '\uFE0F';
+        const char combiningAcute = '\u0301';
+        const char confusableDash = '\u2014';
+        const string emojiTagSequence = "\U0001F3F4\U000E0067\U000E0062\U000E0073\U000E0065\U000E0063\U000E0074\U000E007F";
 
-        char ZWSP = '\u200B', ZWNJ = '\u200C', ZWJ = '\u200D', WJ = '\u2060',
-             FEFF = '\uFEFF', SHY = '\u00AD', NBSP = '\u00A0', LRM = '\u200E',
-             RLM = '\u200F', INVS = '\u2063', INVT = '\u2062', INVP = '\u2064';
-
-        var lines = new[]
-        {
-            $"Это строка с невидимым символом между сло{ZWSP}вами.",
-            $"В этом слове межбуквенный ZWNJ: ма{ZWNJ}штаб.",
-            $"А здесь ZWJ: ко{ZWJ}мпания.",
-            $"Неразрывный пробел между словами: 'Красная{NBSP}площадь'.",
-            $"Мягкий перенос в слове: пре{SHY}ображение.",
-            $"WORD JOINER между цифрами: 123{WJ}456.",
-            $"FEFF внутри строки: до{FEFF}м.",
-            $"LRM после запятой: привет,{LRM} мир.",
-            $"RLM перед словом: привет {RLM}мир.",
-            $"Invisible Separator U+2063: A{INVS}B.",
-            $"Invisible Times U+2062: 2{INVT}x.",
-            $"Invisible Plus U+2064: A{INVP}B.",
-        };
-
-        // Сбор попаданий: (№, line, col, alias, code, uname, context)
-        var hits = new List<(int N, int Line, int Col, string Alias, string Code, string UName, string Ctx)>();
-        var counter = 0;
-
-        for (var ln = 0; ln < lines.Length; ln++)
-        {
-            var text = lines[ln];
-            for (var i = 0; i < text.Length; i++)
-            {
-                var ch = text[i];
-                if (!invSet.Contains(ch)) continue;
-
-                counter++;
-                var code = $"U+{(int)ch:X4}";
-                var meta = inv[ch];
-                var ctx = BuildContext(text, i, invSet, 8, 40);
-
-                hits.Add((counter, ln + 1, i + 1, meta.Alias, code, meta.UnicodeName, ctx));
-            }
-        }
-
-        // Markdown
-        var sb = new StringBuilder();
-        sb.AppendLine("# Invisible Unicode Characters — Demonstration File");
-        sb.AppendLine("> This file is UTF-8. It **intentionally** hides invisible Unicode characters inside the sample text below.");
-        sb.AppendLine("> Use the **Map of occurrences** to locate each hidden character by line and column.");
-        sb.AppendLine();
-        sb.AppendLine("## Sample text (contains invisible characters)");
-        sb.AppendLine("```text");
-        foreach (var l in lines) sb.AppendLine(l);
-        sb.AppendLine("```");
-        sb.AppendLine();
-        sb.AppendLine("## Map of invisible characters (positions)");
-        sb.AppendLine("Each row has: index, 1-based line and column, short alias, code point, Unicode name, and context where the exact position is marked as `⟦◻⟧`.");
-        sb.AppendLine();
-        sb.AppendLine("| # | Line | Col | Alias | Code | Unicode name | Context |");
-        sb.AppendLine("|---:|----:|----:|:------|:-----|:-------------|:--------|");
-        foreach (var h in hits)
-        {
-            sb.Append("| ").Append(h.N)
-              .Append(" | ").Append(h.Line)
-              .Append(" | ").Append(h.Col)
-              .Append(" | ").Append(h.Alias)
-              .Append(" | ").Append(h.Code)
-              .Append(" | ").Append(h.UName)
-              .Append(" | ").Append(EscapePipes(h.Ctx))
-              .AppendLine(" |");
-        }
-
-        sb.AppendLine();
-        sb.AppendLine("## Legend");
-        sb.AppendLine("- **ZWSP** — ZERO WIDTH SPACE (\\u200B)");
-        sb.AppendLine("- **ZWNJ** — ZERO WIDTH NON-JOINER (\\u200C)");
-        sb.AppendLine("- **ZWJ** — ZERO WIDTH JOINER (\\u200D)");
-        sb.AppendLine("- **WJ** — WORD JOINER (\\u2060)");
-        sb.AppendLine("- **FEFF** — ZERO WIDTH NO-BREAK SPACE / BOM (\\uFEFF)");
-        sb.AppendLine("- **SHY** — SOFT HYPHEN (\\u00AD)");
-        sb.AppendLine("- **NBSP** — NO-BREAK SPACE (\\u00A0)");
-        sb.AppendLine("- **LRM** — LEFT-TO-RIGHT MARK (\\u200E)");
-        sb.AppendLine("- **RLM** — RIGHT-TO-LEFT MARK (\\u200F)");
-        sb.AppendLine("- **INVISIBLE SEPARATOR** — \\u2063");
-        sb.AppendLine("- **INVISIBLE TIMES** — \\u2062");
-        sb.AppendLine("- **INVISIBLE PLUS** — \\u2064");
-        sb.AppendLine();
-        sb.AppendLine("### Tips");
-        sb.AppendLine("- To reveal positions in many editors, toggle *Show Invisibles* or paste the text into a hex/Unicode inspector.");
-        sb.AppendLine("- Some tools may strip or normalize these characters on copy/paste.");
-
-        return sb.ToString();
+        var builder = new StringBuilder();
+        builder.AppendLine("## Compact invisible character sample");
+        builder.AppendLine("Each bullet hides one character type handled by the cleaner.");
+        builder.AppendLine();
+        builder.AppendLine($"- Control character: ping{control}pong");
+        builder.AppendLine($"- Tab character: left{tab}right");
+        builder.AppendLine($"- Exotic line break: top{lineSeparator}bottom");
+        builder.AppendLine($"- Wide space: label{thinSpace}value");
+        builder.AppendLine($"- Non-breaking space: keep{nonBreakingSpace}together");
+        builder.AppendLine($"- Zero-width format: join{zeroWidthSpace}ed");
+        builder.AppendLine($"- BiDi mark: start{leftToRightMark}end");
+        builder.AppendLine($"- Soft hyphen: re{softHyphen}order");
+        builder.AppendLine($"- Invisible math separator: 2{invisibleSeparator}x");
+        builder.AppendLine($"- Variation selector: heart\u2764{variationSelector}");
+        builder.AppendLine($"- Emoji tag sequence: flag{emojiTagSequence}");
+        builder.AppendLine($"- Combining mark: accent e{combiningAcute}");
+        builder.AppendLine($"- Confusable dash: word{confusableDash}dash");
+        return builder.ToString();
     }
-
-    private static string BuildContext(string text, int index, HashSet<char> invSet, int windowVisible = 8, int maxWidth = 40)
-    {
-        // Собираем по windowVisible видимых символов слева/справа, игнорируя другие невидимые
-        var left = new StringBuilder();
-        for (var i = index - 1; i >= 0 && left.Length < windowVisible; i--)
-        {
-            if (!invSet.Contains(text[i])) left.Insert(0, text[i]);
-        }
-        var right = new StringBuilder();
-        for (var i = index + 1; i < text.Length && right.Length < windowVisible; i++)
-        {
-            if (!invSet.Contains(text[i])) right.Append(text[i]);
-        }
-
-        var ctx = $"…{left}⟦◻⟧{right}…";
-        return Shorten(ctx, maxWidth);
-    }
-
-    private static string Shorten(string s, int maxWidth)
-    {
-        if (s.Length <= maxWidth) return s;
-        // Простейшее усечение с многоточием посередине
-        var keep = maxWidth - 1; // с учётом '…'
-        if (keep <= 0) return "…";
-        return s.Substring(0, keep) + "…";
-    }
-
-    private static string EscapePipes(string s) => s.Replace("|", "\\|");
 }

--- a/Demo/Pages/MarkdownToWord.razor
+++ b/Demo/Pages/MarkdownToWord.razor
@@ -1,5 +1,4 @@
 ﻿@page "/markdown-to-word"
-@using System.IO
 @using System.Text
 @using Demo.Demos.MarkdownToWord
 @using Demo.Services
@@ -32,9 +31,8 @@
     gap: 8px;
 }
 
-.dropdown-toggle-split {
-    padding-left: 0.375rem;
-    padding-right: 0.375rem;
+.control-group select {
+    flex: 1;
 }
 
 .cleaning-report {
@@ -58,48 +56,41 @@
     <div class="invisible-char-controls">
         <div class="row mb-3">
             <div class="col-md-6">
-                <!-- Mode toggle -->
                 <div class="btn-group d-flex" role="group">
-                    <input type="radio" 
-                           class="btn-check" 
-                           name="viewMode" 
-                           id="preview" 
+                    <input type="radio"
+                           class="btn-check"
+                           name="viewMode"
+                           id="preview"
                            checked="@(CurrentViewMode == ViewMode.Preview)"
                            @onchange="@(() => SetViewMode(ViewMode.Preview))" />
                     <label class="btn btn-outline-primary flex-fill" for="preview">Preview</label>
 
-                    <input type="radio" 
-                           class="btn-check" 
-                           name="viewMode" 
-                           id="invisibleChars" 
+                    <input type="radio"
+                           class="btn-check"
+                           name="viewMode"
+                           id="invisibleChars"
                            checked="@(CurrentViewMode == ViewMode.InvisibleCharacters)"
                            @onchange="@(() => SetViewMode(ViewMode.InvisibleCharacters))" />
                     <label class="btn btn-outline-primary flex-fill" for="invisibleChars">Invisible Characters</label>
                 </div>
             </div>
-            
+
             <div class="col-md-6">
-                <!-- Additional cleaning presets -->
-                <div class="btn-group w-100">
-                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
-                        Presets (@SelectedPreset)
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li><h6 class="dropdown-header">Cleaning Presets</h6></li>
-                        <li><button class="dropdown-item" @onclick="() => SelectPreset(CleaningPreset.Safe)">Safe</button></li>
-                        <li><button class="dropdown-item" @onclick="() => SelectPreset(CleaningPreset.Aggressive)">Aggressive</button></li>
-                        <li><button class="dropdown-item" @onclick="() => SelectPreset(CleaningPreset.ASCIIStrict)">ASCII-Strict</button></li>
-                        <li><button class="dropdown-item" @onclick="() => SelectPreset(CleaningPreset.TypographySoft)">Typography-Soft</button></li>
-                        <li><button class="dropdown-item" @onclick="() => SelectPreset(CleaningPreset.RTLSafe)">RTL-Safe</button></li>
-                        <li><button class="dropdown-item" @onclick="() => SelectPreset(CleaningPreset.SEOPlain)">SEO/Plain</button></li>
-                        <li><hr class="dropdown-divider"></li>
-                        <li><button class="dropdown-item" @onclick="CleanText">Apply Preset</button></li>
-                    </ul>
+                <div class="control-group w-100">
+                    <label class="form-label mb-0" for="presetSelect">Cleaning preset</label>
+                    <select id="presetSelect" class="form-select" @bind="SelectedPreset">
+                        <option value="@CleaningPreset.Safe">Safe</option>
+                        <option value="@CleaningPreset.Aggressive">Aggressive</option>
+                        <option value="@CleaningPreset.ASCIIStrict">ASCII-Strict</option>
+                        <option value="@CleaningPreset.TypographySoft">Typography-Soft</option>
+                        <option value="@CleaningPreset.RTLSafe">RTL-Safe</option>
+                        <option value="@CleaningPreset.SEOPlain">SEO/Plain</option>
+                    </select>
+                    <button type="button" class="btn btn-outline-secondary" @onclick="CleanText">Apply</button>
                 </div>
             </div>
         </div>
-        
-        <!-- Селекторы категорий (показываем только в режиме невидимых символов) -->
+
         @if (CurrentViewMode == ViewMode.InvisibleCharacters)
         {
             <div class="row mb-3">
@@ -134,17 +125,12 @@
         
         <div class="row mb-3">
             <div class="col-md-6">
-                <!-- Clean selected categories button -->
                 <button class="btn btn-warning w-100" @onclick="DeleteInvisibleCharacters" disabled="@(!HasInvisibleCharactersInEnabledCategories)">
                     Clean Selected (@InvisibleCharacterCount)
                 </button>
             </div>
-            <div class="col-md-6">
-                <!-- Highlight mode -->
-                <select class="form-select" @bind="CurrentHighlightMode" @bind:after="OnHighlightModeChanged">
-                    <option value="@HighlightMode.ByCategory">By Category</option>
-                    <option value="@HighlightMode.AllSame">All Same</option>
-                </select>
+            <div class="col-md-6 d-flex align-items-center justify-content-md-end">
+                <span class="text-muted small">Highlights are color-coded by category.</span>
             </div>
         </div>
 
@@ -167,7 +153,7 @@
             <button class="btn btn-secondary" @onclick='() => ToggleMarkdownAction("_")' style="font-style: italic;">I</button>
             <button class="btn btn-secondary" @onclick='() => ToggleMarkdownAction("~~")' style="text-decoration: line-through;">S</button>
             <button class="btn btn-secondary" @onclick='() => ToggleMarkdownAction("`")' style="font-family: monospace;">`code`</button>
-            <button class="btn btn-info ms-3" @onclick="LoadExample" title="Load Russian text with invisible characters for testing">Show Example</button>
+            <button class="btn btn-info ms-3" @onclick="LoadExample" title="Load compact text with invisible characters for testing">Show Example</button>
         </div>
     </div>
 
@@ -199,7 +185,6 @@
 </div>
 
 @code {
-    // Enum для режимов просмотра
     private enum ViewMode
     {
         Preview,
@@ -216,12 +201,10 @@
         .UseEmphasisExtras()
         .Build();
 
-    // Invisible character feature properties
     private ViewMode CurrentViewMode { get; set; } = ViewMode.Preview;
     private bool ShowInvisibleCharacters => CurrentViewMode == ViewMode.InvisibleCharacters;
     private HashSet<InvisibleCharacterCategory> EnabledCategories { get; set; } = new();
-    
-    // Computed properties for UI
+
     private bool HasInvisibleCharactersInEnabledCategories
     {
         get
@@ -247,7 +230,6 @@
     }
     
     private CleaningPreset SelectedPreset { get; set; } = CleaningPreset.Safe;
-    private HighlightMode CurrentHighlightMode { get; set; } = HighlightMode.ByCategory;
     private string LastCleaningReport { get; set; } = string.Empty;
     private bool LastCleaningHasError { get; set; } = false;
     private bool CanUndo { get; set; } = false;
@@ -259,7 +241,6 @@
         ShowInvisibleCharacters = ShowInvisibleCharacters,
         SkipCodeBlocks = true,
         ShowLineBreaks = true,
-        HighlightMode = CurrentHighlightMode,
         EnabledCategories = EnabledCategories
     };
 
@@ -268,25 +249,9 @@
         base.OnInitialized();
         PageTitleService.SetTitle("Markdown to Word");
         
-        // Initialize all categories as enabled by default
         EnabledCategories = Enum.GetValues<InvisibleCharacterCategory>().ToHashSet();
         
         await UpdatePreview();
-    }
-
-    private async Task OnHighlightModeChanged()
-    {
-        if (CurrentViewMode == ViewMode.InvisibleCharacters)
-        {
-            await UpdatePreview();
-            StateHasChanged();
-        }
-    }
-
-    private void SelectPreset(CleaningPreset preset)
-    {
-        SelectedPreset = preset;
-        StateHasChanged();
     }
 
     private async Task CleanText()
@@ -297,18 +262,18 @@
             
             if (cleaningResult.HasChanges)
             {
-                // Store for undo
+                // Cache content for undo
                 UndoContent = MarkdownContent;
                 CanUndo = true;
-                
+
                 // Apply cleaned text
                 MarkdownContent = cleaningResult.CleanedText;
                 LastCleaningReport = cleaningResult.Summary;
                 LastCleaningHasError = false;
-                
+
                 // Update the textarea
                 await JSRuntime.InvokeVoidAsync("updateTextAreaContent", MarkdownTextArea, MarkdownContent);
-                
+
                 await UpdatePreview();
             }
             else
@@ -403,7 +368,6 @@
         DownloadUrl = "data:application/msword;base64," + Convert.ToBase64String(byteArray);
     }
 
-    // Новые методы для работы с режимами и категориями
     private async Task SetViewMode(ViewMode mode)
     {
         CurrentViewMode = mode;
@@ -433,19 +397,19 @@
 
         try
         {
-            // Сохраняем для отмены
+            // Cache content for undo
             UndoContent = MarkdownContent;
-            
-            // Получаем детекцию символов
+
+            // Detect invisible characters in the current content
             var detectionResult = CharacterDetector.DetectInvisibleCharacters(MarkdownContent);
-            
-            // Создаем список символов для удаления (только из включенных категорий)
+
+            // Collect characters from enabled categories only
             var charactersToRemove = detectionResult.DetectedCharacters
                 .Where(dc => EnabledCategories.Contains(dc.Category))
-                .OrderByDescending(dc => dc.Position) // Удаляем с конца чтобы не сбить позиции
+                .OrderByDescending(dc => dc.Position) // Remove from the end to preserve positions
                 .ToList();
-            
-            // Удаляем символы
+
+            // Remove characters
             var cleanedText = MarkdownContent;
             int removedCount = 0;
             var removedCategories = new Dictionary<InvisibleCharacterCategory, int>();
@@ -522,7 +486,7 @@
         await JSRuntime.InvokeVoidAsync("updateTextAreaContent", MarkdownTextArea, MarkdownContent);
         await UpdatePreview();
         
-        LastCleaningReport = "Russian demo text loaded with invisible characters for testing.";
+        LastCleaningReport = "Compact demo text loaded with invisible characters for testing.";
         LastCleaningHasError = false;
         
         StateHasChanged();

--- a/Demo/Services/InvisibleCharacterVisualizationService.cs
+++ b/Demo/Services/InvisibleCharacterVisualizationService.cs
@@ -45,8 +45,7 @@ namespace Demo.Services
                 }
                 else if (options.ShowLineBreaks && rune.Value == 0x000A) // LF
                 {
-                    // Show line break marker even if LF is not detected as invisible character
-                    var cssClass = GetCssClass(InvisibleCharacterCategory.LineBreaks, options.HighlightMode);
+                    var cssClass = GetCssClass(InvisibleCharacterCategory.LineBreaks);
                     var marker = "¶";
                     var tooltip = "Line Feed (LF)";
                     var codePoint = "U+000A";
@@ -69,7 +68,7 @@ namespace Demo.Services
 
         private string VisualizeCharacter(CharacterDetection detection, Rune rune, VisualizationOptions options)
         {
-            var cssClass = GetCssClass(detection.Category, options.HighlightMode);
+            var cssClass = GetCssClass(detection.Category);
             var marker = GetVisualMarker(detection, rune);
             var tooltip = HttpUtility.HtmlAttributeEncode(detection.Tooltip);
             var codePoint = detection.CodePointString;
@@ -78,19 +77,9 @@ namespace Demo.Services
             // Special handling for line breaks - show marker at end of line
             if (detection.Category == InvisibleCharacterCategory.LineBreaks)
             {
-                if (rune.Value == 0x000A) // LF
-                {
-                    return options.ShowLineBreaks 
-                        ? $"<span class=\"{cssClass}\" data-code=\"{codePoint}\" data-name=\"{name}\" title=\"{tooltip}\">{marker}</span>\n"
-                        : "\n";
-                }
-                else
-                {
-                    // CR, NEL, LS, PS - show marker and convert to LF
-                    return options.ShowLineBreaks 
-                        ? $"<span class=\"{cssClass}\" data-code=\"{codePoint}\" data-name=\"{name}\" title=\"{tooltip}\">{marker}</span>\n"
-                        : "\n";
-                }
+                return options.ShowLineBreaks
+                    ? $"<span class=\"{cssClass}\" data-code=\"{codePoint}\" data-name=\"{name}\" title=\"{tooltip}\">{marker}</span>\n"
+                    : "\n";
             }
 
             // Special handling for TAB - show marker with visual tab alignment
@@ -125,10 +114,10 @@ namespace Demo.Services
             };
         }
 
-        private string GetCssClass(InvisibleCharacterCategory category, HighlightMode mode)
+        private string GetCssClass(InvisibleCharacterCategory category)
         {
             var baseClass = "inv-char";
-            var categoryClass = mode == HighlightMode.ByCategory ? $"inv-{GetCategoryName(category).ToLower()}" : "inv-all";
+            var categoryClass = $"inv-{GetCategoryName(category).ToLower()}";
             return $"{baseClass} {categoryClass}";
         }
 
@@ -204,82 +193,49 @@ namespace Demo.Services
             return @"
 .inv-char {
     position: relative;
-    border-radius: 2px;
-    font-family: 'Courier New', monospace;
-    font-size: 0.85em;
-    font-weight: bold;
-    padding: 0 2px;
-    margin: 0 1px;
-    display: inline-block;
-    cursor: help;
-}
-
-/* Category-specific colors */
-.inv-control { background-color: rgba(255, 99, 99, 0.3); color: #cc0000; }
-.inv-linebreak { background-color: rgba(99, 255, 99, 0.3); color: #006600; }
-.inv-tab { background-color: rgba(99, 99, 255, 0.3); color: #000066; }
-.inv-widespace { background-color: rgba(255, 255, 99, 0.3); color: #666600; }
-.inv-nbsp { background-color: rgba(255, 165, 0, 0.3); color: #cc6600; }
-.inv-zerowidth { background-color: rgba(255, 99, 255, 0.3); color: #990099; }
-.inv-bidi { background-color: rgba(255, 192, 203, 0.3); color: #990066; }
-.inv-softhyphen { background-color: rgba(192, 192, 192, 0.3); color: #666666; }
-.inv-invismath { background-color: rgba(144, 238, 144, 0.3); color: #006633; }
-.inv-varsel { background-color: rgba(173, 216, 230, 0.3); color: #336699; }
-.inv-emotag { background-color: rgba(221, 160, 221, 0.3); color: #663366; }
-.inv-combining { background-color: rgba(255, 218, 185, 0.3); color: #994400; }
-.inv-confusable { background-color: rgba(255, 140, 0, 0.3); color: #cc4400; }
-
-/* All same color mode */
-.inv-all { background-color: rgba(255, 182, 193, 0.4); color: #990033; }
-
-/* Hover effects */
-.inv-char:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-    transform: scale(1.1);
-    z-index: 1000;
-}
-
-/* Tooltip styling */
-.inv-char[title]:hover::after {
-    content: attr(title);
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: #333;
-    color: white;
-    padding: 4px 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border-radius: 4px;
-    font-size: 12px;
-    white-space: nowrap;
-    z-index: 1001;
-    margin-bottom: 4px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.85em;
+    font-weight: 600;
+    padding: 0 4px;
+    margin: 0 1px;
+    line-height: 1.4;
+    cursor: help;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.inv-char[title]:hover::before {
-    content: '';
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 4px solid transparent;
-    border-top-color: #333;
-    z-index: 1001;
+.inv-char:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    z-index: 5;
 }
 
-/* Tab visualization specific styling */
+.inv-control { background-color: #ffd6d6; color: #a91f1f; }
+.inv-linebreak { background-color: #d0f4de; color: #1f6f3d; }
+.inv-tab { background-color: #d7dcff; color: #2430a0; }
+.inv-widespace { background-color: #fff2b2; color: #856404; }
+.inv-nbsp { background-color: #ffe0c7; color: #9b4d16; }
+.inv-zerowidth { background-color: #f5d0ff; color: #7e1b8d; }
+.inv-bidi { background-color: #ffd9ec; color: #a11963; }
+.inv-softhyphen { background-color: #e4e7eb; color: #4b5563; }
+.inv-invismath { background-color: #d2f8d2; color: #2b7a0b; }
+.inv-varsel { background-color: #d0ebff; color: #216fa0; }
+.inv-emotag { background-color: #ffe6a7; color: #8a4f0f; }
+.inv-combining { background-color: #ffd5f2; color: #a60f63; }
+.inv-confusable { background-color: #ffe8cc; color: #8c4a03; }
+
 .inv-tab {
-    min-width: 2em;
-    text-align: left;
+    min-width: 2.5ch;
+    justify-content: flex-start;
 }
 
-/* Line break visualization */
 .inv-linebreak {
-    position: absolute;
-    right: -1em;
-    font-size: 0.8em;
-}";
+    min-width: 2ch;
+}
+";
         }
     }
 
@@ -288,18 +244,11 @@ namespace Demo.Services
         public bool ShowInvisibleCharacters { get; set; } = false;
         public bool SkipCodeBlocks { get; set; } = true;
         public bool ShowLineBreaks { get; set; } = true;
-        public HighlightMode HighlightMode { get; set; } = HighlightMode.ByCategory;
         public HashSet<InvisibleCharacterCategory> EnabledCategories { get; set; } = new();
 
         public static VisualizationOptions Default => new()
         {
             EnabledCategories = Enum.GetValues<InvisibleCharacterCategory>().ToHashSet()
         };
-    }
-
-    public enum HighlightMode
-    {
-        ByCategory,
-        AllSame
     }
 }

--- a/DemoTests/InvisibleCharacters/InvisibleCharacterVisualizationServiceTests.cs
+++ b/DemoTests/InvisibleCharacters/InvisibleCharacterVisualizationServiceTests.cs
@@ -158,37 +158,6 @@ namespace DemoTests.InvisibleCharacters
         }
 
         [Fact]
-        public void VisualizeInvisibleCharacters_HighlightModeByCategory_UsesCategoryClasses()
-        {
-            var input = "\u0001\u200B"; // Control + ZWSP
-            var options = new VisualizationOptions 
-            { 
-                ShowInvisibleCharacters = true, 
-                HighlightMode = HighlightMode.ByCategory 
-            };
-            var result = _visualizer.VisualizeInvisibleCharacters(input, options);
-            
-            Assert.Contains("inv-control", result);
-            Assert.Contains("inv-zerowidth", result);
-        }
-
-        [Fact]
-        public void VisualizeInvisibleCharacters_HighlightModeAllSame_UsesGenericClass()
-        {
-            var input = "\u0001\u200B"; // Control + ZWSP
-            var options = new VisualizationOptions 
-            { 
-                ShowInvisibleCharacters = true, 
-                HighlightMode = HighlightMode.AllSame 
-            };
-            var result = _visualizer.VisualizeInvisibleCharacters(input, options);
-            
-            Assert.Contains("inv-all", result);
-            Assert.DoesNotContain("inv-control", result);
-            Assert.DoesNotContain("inv-zerowidth", result);
-        }
-
-        [Fact]
         public void VisualizeInvisibleCharacters_SkipCodeBlocks_IgnoresInCode()
         {
             var input = "Text `with\u200Bcode` and\u200Cmore.";


### PR DESCRIPTION
## Summary
- replace the Markdown-to-Word preset dropdown with a simple selector, drop the highlight mode toggle, and surface a color-coded hint
- refresh invisible character visualization styling so each category has its own palette without the overlapping tooltip
- rebuild the demo text generator to provide a compact sample that still includes every removable character category and update tests accordingly

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet test Demo.sln` *(fails: requires wasm-tools workload)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd5a86c20832aa9844fcf56a0b119