### PR TITLE
Improve invisible character cleaning feedback

### DIFF
--- a/Demo/Pages/MarkdownToWord.razor
+++ b/Demo/Pages/MarkdownToWord.razor
@@ -122,13 +122,10 @@
         }
         
         <div class="row mb-3">
-            <div class="col-md-6">
-                <button class="btn btn-warning w-100" @onclick="DeleteInvisibleCharacters" disabled="@(!HasInvisibleCharactersInEnabledCategories)">
-                    Clean Selected (@InvisibleCharacterCount)
+            <div class="col-12 col-md-6 col-lg-4">
+                <button class="btn btn-warning w-100" @onclick="DeleteInvisibleCharacters" disabled="@(!HasCharactersToClean)">
+                    Clean Selected (@CharactersToCleanCount)
                 </button>
-            </div>
-            <div class="col-md-6 d-flex align-items-center justify-content-md-end">
-                <span class="text-muted small">Highlights are color-coded by category.</span>
             </div>
         </div>
 
@@ -194,6 +191,7 @@
     private string MarkdownPreview { get; set; } = string.Empty;
     private string VisualizedPreview { get; set; } = string.Empty;
     private string DownloadUrl { get; set; } = string.Empty;
+    private DetectionResult LatestDetectionResult { get; set; } = new();
     private Markdig.MarkdownPipeline MarkdownPipeline =
         new Markdig.MarkdownPipelineBuilder()
         .UseEmphasisExtras()
@@ -304,29 +302,12 @@
         }
     }
 
-    private bool HasInvisibleCharactersInEnabledCategories
-    {
-        get
-        {
-            if (string.IsNullOrEmpty(MarkdownContent) || EnabledCategories.Count == 0)
-                return false;
+    private bool HasCharactersToClean => EnabledCategories.Count > 0 &&
+        LatestDetectionResult.DetectedCharacters.Any(dc => EnabledCategories.Contains(dc.Category));
 
-            var detectionResult = CharacterDetector.DetectInvisibleCharacters(MarkdownContent);
-            return detectionResult.DetectedCharacters.Any(dc => EnabledCategories.Contains(dc.Category));
-        }
-    }
-    
-    private int InvisibleCharacterCount
-    {
-        get
-        {
-            if (string.IsNullOrEmpty(MarkdownContent) || EnabledCategories.Count == 0)
-                return 0;
-
-            var detectionResult = CharacterDetector.DetectInvisibleCharacters(MarkdownContent);
-            return detectionResult.DetectedCharacters.Count(dc => EnabledCategories.Contains(dc.Category));
-        }
-    }
+    private int CharactersToCleanCount => EnabledCategories.Count == 0
+        ? 0
+        : LatestDetectionResult.DetectedCharacters.Count(dc => EnabledCategories.Contains(dc.Category));
     
     private string LastCleaningReport { get; set; } = string.Empty;
     private bool LastCleaningHasError { get; set; } = false;
@@ -405,19 +386,21 @@
 
     private Task UpdatePreview()
     {
-        MarkdownPreview = Markdig.Markdown.ToHtml(MarkdownContent, MarkdownPipeline);
-        
+        var content = MarkdownContent ?? string.Empty;
+        LatestDetectionResult = CharacterDetector.DetectInvisibleCharacters(content);
+        MarkdownPreview = Markdig.Markdown.ToHtml(content, MarkdownPipeline);
+
         if (CurrentViewMode == ViewMode.InvisibleCharacters)
         {
             // Generate visualized preview with only enabled categories
-            var visualizedMarkdown = CharacterVisualizer.VisualizeInvisibleCharacters(MarkdownContent, VisualizationOptions);
+            var visualizedMarkdown = CharacterVisualizer.VisualizeInvisibleCharacters(content, VisualizationOptions);
             VisualizedPreview = Markdig.Markdown.ToHtml(visualizedMarkdown, MarkdownPipeline);
         }
         else
         {
             VisualizedPreview = MarkdownPreview;
         }
-        
+
         GenerateDownloadUrl();
         return Task.CompletedTask;
     }
@@ -463,7 +446,7 @@
 
     private async Task DeleteInvisibleCharacters()
     {
-        if (!HasInvisibleCharactersInEnabledCategories)
+        if (!HasCharactersToClean)
             return;
 
         try

--- a/Demo/Services/InvisibleCharacterDetectorService.cs
+++ b/Demo/Services/InvisibleCharacterDetectorService.cs
@@ -94,14 +94,20 @@ namespace Demo.Services
             { 0x201D, "\"" }, // RIGHT DOUBLE QUOTATION MARK → ASCII
             { 0x2018, "'" }, // LEFT SINGLE QUOTATION MARK → ASCII
             { 0x2019, "'" }, // RIGHT SINGLE QUOTATION MARK → ASCII
-            
+
             // Dashes
             { 0x2212, "-" }, // MINUS SIGN → HYPHEN-MINUS
             { 0x2013, "-" }, // EN DASH → HYPHEN-MINUS
             { 0x2014, "-" }, // EM DASH → HYPHEN-MINUS
-            
-            // Note: Cyrillic/Latin lookalikes removed as they are normal characters in Russian text
-            // Only include these if specifically processing mixed-script documents where confusion is likely
+
+            // Cyrillic lookalikes
+            { 0x0430, "a" }, // CYRILLIC SMALL LETTER A → LATIN
+            { 0x0435, "e" }, // CYRILLIC SMALL LETTER IE → LATIN
+            { 0x043E, "o" }, // CYRILLIC SMALL LETTER O → LATIN
+            { 0x0440, "p" }, // CYRILLIC SMALL LETTER ER → LATIN
+            { 0x0441, "c" }, // CYRILLIC SMALL LETTER ES → LATIN
+            { 0x0443, "y" }, // CYRILLIC SMALL LETTER U → LATIN
+            { 0x0445, "x" }  // CYRILLIC SMALL LETTER HA → LATIN
         };
 
         static InvisibleCharacterDetectorService()

--- a/DemoTests/InvisibleCharacters/InvisibleCharacterVisualizationServiceTests.cs
+++ b/DemoTests/InvisibleCharacters/InvisibleCharacterVisualizationServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Demo.Services;
 using Xunit;
 
@@ -85,16 +86,37 @@ namespace DemoTests.InvisibleCharacters
         public void VisualizeInvisibleCharacters_LineBreakDisabled_NoMarker()
         {
             var input = "Line1\nLine2";
-            var options = new VisualizationOptions 
-            { 
-                ShowInvisibleCharacters = true, 
-                ShowLineBreaks = false 
+            var options = new VisualizationOptions
+            {
+                ShowInvisibleCharacters = true,
+                ShowLineBreaks = false
             };
             var result = _visualizer.VisualizeInvisibleCharacters(input, options);
-            
+
             // Should not show line break marker
             Assert.DoesNotContain("¶", result);
             Assert.Contains("\n", result); // But should still have the actual newline
+        }
+
+        [Fact]
+        public void VisualizeInvisibleCharacters_LineBreakCategoryDisabled_NoMarker()
+        {
+            var input = "Line1\nLine2";
+            var options = new VisualizationOptions
+            {
+                ShowInvisibleCharacters = true,
+                ShowLineBreaks = true,
+                EnabledCategories = new HashSet<InvisibleCharacterCategory>
+                {
+                    InvisibleCharacterCategory.ZeroWidthFormat
+                }
+            };
+
+            var result = _visualizer.VisualizeInvisibleCharacters(input, options);
+
+            Assert.DoesNotContain("inv-linebreak", result);
+            Assert.DoesNotContain("¶", result);
+            Assert.Contains("\n", result);
         }
 
         [Fact]
@@ -127,10 +149,29 @@ namespace DemoTests.InvisibleCharacters
             var input = "Text\u200BWithZWSP";
             var options = new VisualizationOptions { ShowInvisibleCharacters = true };
             var result = _visualizer.VisualizeInvisibleCharacters(input, options);
-            
+
             Assert.Contains("inv-zerowidth", result);
             Assert.Contains("ZWSP", result);
             Assert.Contains("U+200B", result);
+        }
+
+        [Fact]
+        public void VisualizeInvisibleCharacters_DisabledCategory_HidesMarkers()
+        {
+            var input = "Hello\u200BWorld";
+            var options = new VisualizationOptions
+            {
+                ShowInvisibleCharacters = true,
+                EnabledCategories = new HashSet<InvisibleCharacterCategory>
+                {
+                    InvisibleCharacterCategory.LineBreaks
+                }
+            };
+
+            var result = _visualizer.VisualizeInvisibleCharacters(input, options);
+
+            Assert.DoesNotContain("inv-zerowidth", result);
+            Assert.DoesNotContain("ZWSP", result);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- remove the highlight legend, refresh preview on preset changes, and show the number of invisible characters that will be cleaned
- filter the visualization output by enabled categories and default options to include every category
- expand the confusables map with Cyrillic lookalikes and extend the visualization tests for disabled categories

## Testing
- MSBUILDTERMINALLOGGER=false dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68cbe0bd49b0832a898e054b9f4a7910