### PR TITLE
Improve line break cleaning feedback and preview list spacing

### DIFF
--- a/Demo/Pages/MarkdownToWord.razor
+++ b/Demo/Pages/MarkdownToWord.razor
@@ -38,6 +38,23 @@
     white-space: normal;
     line-height: 1.2;
 }
+
+#preview ul,
+#preview ol {
+    white-space: normal;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    padding-left: 1.5rem;
+}
+
+#preview li {
+    margin-bottom: 0.25rem;
+    line-height: 1.25;
+}
+
+#preview li:last-child {
+    margin-bottom: 0;
+}
 </style>
 
 <PageTitle>Markdown to Word</PageTitle>

--- a/Demo/Services/InvisibleCharacterVisualizationService.cs
+++ b/Demo/Services/InvisibleCharacterVisualizationService.cs
@@ -23,6 +23,7 @@ namespace Demo.Services
         {
             var sb = new StringBuilder();
             var detectionsByPosition = detection.DetectedCharacters.ToDictionary(d => d.Position, d => d);
+            var hasLineBreakDetections = detection.DetectedCharacters.Any(d => d.Category == InvisibleCharacterCategory.LineBreaks);
             var codeBlockRanges = options.SkipCodeBlocks ? FindCodeBlockRanges(input) : new List<(int start, int end)>();
 
             int position = 0;
@@ -48,7 +49,7 @@ namespace Demo.Services
                         sb.Append(HttpUtility.HtmlEncode(rune.ToString()));
                     }
                 }
-                else if (ShouldRenderLineFeed(rune, options))
+                else if (ShouldRenderLineFeed(rune, options, hasLineBreakDetections))
                 {
                     var cssClass = GetCssClass(InvisibleCharacterCategory.LineBreaks);
                     var marker = "¶";
@@ -84,8 +85,13 @@ namespace Demo.Services
             return options.ShowInvisibleCharacters;
         }
 
-        private static bool ShouldRenderLineFeed(Rune rune, VisualizationOptions options)
+        private static bool ShouldRenderLineFeed(Rune rune, VisualizationOptions options, bool hasLineBreakDetections)
         {
+            if (!hasLineBreakDetections)
+            {
+                return false;
+            }
+
             return rune.Value == 0x000A &&
                    options.ShowLineBreaks &&
                    IsCategoryEnabled(InvisibleCharacterCategory.LineBreaks, options);


### PR DESCRIPTION
## Summary
- prevent regular line feeds from rendering as invisible markers when no special line breaks remain so the Line Breaks cleaner gives clear feedback
- tighten markdown preview list spacing by overriding whitespace, margins, and line-height for lists

## Testing
- MSBUILDTERMINALLOGGER=off dotnet test *(fails: requires wasm-tools workload)*

------
https://chatgpt.com/codex/tasks/task_e_68cbed50fb9c832a8306272445e28e4a