### PR TITLE
Fix line break visualization to match cleaning count

### DIFF
--- a/Demo/Services/InvisibleCharacterVisualizationService.cs
+++ b/Demo/Services/InvisibleCharacterVisualizationService.cs
@@ -23,7 +23,6 @@ namespace Demo.Services
         {
             var sb = new StringBuilder();
             var detectionsByPosition = detection.DetectedCharacters.ToDictionary(d => d.Position, d => d);
-            var hasLineBreakDetections = detection.DetectedCharacters.Any(d => d.Category == InvisibleCharacterCategory.LineBreaks);
             var codeBlockRanges = options.SkipCodeBlocks ? FindCodeBlockRanges(input) : new List<(int start, int end)>();
 
             int position = 0;
@@ -49,16 +48,6 @@ namespace Demo.Services
                         sb.Append(HttpUtility.HtmlEncode(rune.ToString()));
                     }
                 }
-                else if (ShouldRenderLineFeed(rune, options, hasLineBreakDetections))
-                {
-                    var cssClass = GetCssClass(InvisibleCharacterCategory.LineBreaks);
-                    var marker = "¶";
-                    var tooltip = "Line Feed (LF)";
-                    var codePoint = "U+000A";
-                    var name = "LINE FEED";
-
-                    sb.Append($"<span class=\"{cssClass}\" data-code=\"{codePoint}\" data-name=\"{name}\" title=\"{tooltip}\">{marker}</span>\n");
-                }
                 else
                 {
                     sb.Append(HttpUtility.HtmlEncode(rune.ToString()));
@@ -83,18 +72,6 @@ namespace Demo.Services
             }
 
             return options.ShowInvisibleCharacters;
-        }
-
-        private static bool ShouldRenderLineFeed(Rune rune, VisualizationOptions options, bool hasLineBreakDetections)
-        {
-            if (!hasLineBreakDetections)
-            {
-                return false;
-            }
-
-            return rune.Value == 0x000A &&
-                   options.ShowLineBreaks &&
-                   IsCategoryEnabled(InvisibleCharacterCategory.LineBreaks, options);
         }
 
         private static bool IsCategoryEnabled(InvisibleCharacterCategory category, VisualizationOptions options)


### PR DESCRIPTION
## Summary
- stop adding visualization markers for regular LF characters when a line-break detection is present
- keep the invisible character preview aligned with the characters that will actually be cleaned

## Testing
- dotnet test Demo.sln *(fails: required `wasm-tools` workload is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc335706e0832a9792f0b5cb222f15