### PR TITLE
Hide dealer ace hint until cards revealed

### DIFF
--- a/Demo/Components/PlayingHand.razor
+++ b/Demo/Components/PlayingHand.razor
@@ -15,7 +15,7 @@
         <div class="hand-info">
             <span class="total-score">Total: @(Hand.AllCardFacedUp ? $"{Hand.HandValue}" : "Secret")</span>
             <span class="badge @(Hand.IsPair ? "badge-active" : "badge-inactive")">Pair</span>
-            <span class="badge @(Hand.IsSoft ? "badge-active" : "badge-inactive")">Soft</span>
+            <span class="badge @((Hand.AllCardFacedUp && Hand.IsSoft) ? "badge-active" : "badge-inactive")">Soft</span>
 
             <div class="bet-label">
                 @if (playerHand != null)


### PR DESCRIPTION
## Summary
- prevent the blackjack dealer's soft badge from highlighting while the hole card is still hidden

## Testing
- dotnet test *(fails: Microsoft.Build.Logging.TerminalLogger.TerminalLogger.WrapText ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68d017b416c0832a911a37bcf8d39e85