### PR TITLE
Improve detection heuristics for confusable Cyrillic letters

### DIFF
--- a/DemoTests/InvisibleCharacters/InvisibleCharacterDetectorServiceTests.cs
+++ b/DemoTests/InvisibleCharacters/InvisibleCharacterDetectorServiceTests.cs
@@ -180,6 +180,33 @@ namespace DemoTests.InvisibleCharacters
         }
 
         [Fact]
+        public void DetectInvisibleCharacters_CyrillicSentence_DoesNotTriggerConfusable()
+        {
+            var input = "Это пример русского текста и обычных слов.";
+            var result = _detector.DetectInvisibleCharacters(input, skipCodeBlocks: false);
+
+            Assert.DoesNotContain(result.DetectedCharacters, d => d.Category == InvisibleCharacterCategory.Confusables);
+        }
+
+        [Fact]
+        public void DetectInvisibleCharacters_SingleCyrillicLetterInRussianContext_DoesNotTriggerConfusable()
+        {
+            var input = "И пример русского текста";
+            var result = _detector.DetectInvisibleCharacters(input, skipCodeBlocks: false);
+
+            Assert.DoesNotContain(result.DetectedCharacters, d => d.Category == InvisibleCharacterCategory.Confusables);
+        }
+
+        [Fact]
+        public void DetectInvisibleCharacters_StandaloneCyrillicInEnglishText_DetectsConfusable()
+        {
+            var input = "This line has letter и among English words.";
+            var result = _detector.DetectInvisibleCharacters(input, skipCodeBlocks: false);
+
+            Assert.Contains(result.DetectedCharacters, d => d.Category == InvisibleCharacterCategory.Confusables && d.CodePoint == 0x0438);
+        }
+
+        [Fact]
         public void DetectInvisibleCharacters_MixedAlphabetWord_DetectsConfusable()
         {
             var input = "pa\u0441sword";


### PR DESCRIPTION
## Summary
- refine the confusable-letter heuristic to analyze word-level script composition and overall script usage counts
- add coverage for Russian sentences, single-letter cases, and English text contamination scenarios

## Testing
- `dotnet test Demo.sln` *(fails: Microsoft.Build.Logging.TerminalLogger.TerminalLogger.WrapText ArgumentOutOfRangeException during build)*

------
https://chatgpt.com/codex/tasks/task_e_68d933a6bec0832ab16e8428a908ddda