### PR TITLE
Fix cleaning of invisible characters when all algorithms selected

### DIFF
--- a/DemoTests/InvisibleCharacters/InvisibleCharacterCleanerServiceTests.cs
+++ b/DemoTests/InvisibleCharacters/InvisibleCharacterCleanerServiceTests.cs
@@ -373,5 +373,31 @@ namespace DemoTests.InvisibleCharacters
             AssertDoesNotContainString(result.CleanedText, "−"); // MINUS SIGN gone
             Assert.Contains("-", result.CleanedText); // Regular hyphen present
         }
+
+        [Fact]
+        public void CleanSelectedCategories_WithAllAlgorithms_RemovesInvisibleCharactersFromDemoExample()
+        {
+            var demoText = InvisibleUnicodeDemoGenerator.BuildMarkdown();
+            var detector = new InvisibleCharacterDetectorService();
+            var cleaner = new InvisibleCharacterCleanerService();
+
+            var initialDetection = detector.DetectInvisibleCharacters(demoText);
+            Assert.True(initialDetection.HasInvisibleCharacters);
+
+            var enabledCategories = Enum.GetValues<InvisibleCharacterCategory>().ToHashSet();
+            var cleaningOptions = new CleaningOptions
+            {
+                SkipCodeBlocks = true,
+                TabSize = 4,
+                InvisibleMathToSpace = true,
+                PreserveZWJZWNJ = false
+            };
+
+            var result = cleaner.CleanSelectedCategories(demoText, enabledCategories, cleaningOptions);
+
+            Assert.False(result.AfterCleaningDetection.HasInvisibleCharacters);
+            Assert.Empty(result.AfterCleaningDetection.DetectedCharacters);
+            Assert.Contains("Comprehensive invisible character test", result.CleanedText);
+        }
     }
 }

--- a/MarkdownToWordDemo/MarkdownToWord/InvisibleCharacterCleanerService.cs
+++ b/MarkdownToWordDemo/MarkdownToWord/InvisibleCharacterCleanerService.cs
@@ -124,10 +124,7 @@ namespace Demo.Demos.MarkdownToWord
             {
                 if (positionsToClean.TryGetValue(position, out var charDetection))
                 {
-                    // Use a more aggressive preset for confusables when explicitly selected
-                    var presetForAction = charDetection.Category == InvisibleCharacterCategory.Confusables
-                        ? CleaningPreset.Aggressive
-                        : CleaningPreset.Safe;
+                    var presetForAction = GetPresetForSelectedCategory(charDetection.Category);
 
                     var cleaningAction = charDetection.GetCleaningAction(presetForAction);
                     var processedChar = ApplyCleaningAction(rune, cleaningAction, new CleaningContext
@@ -267,6 +264,21 @@ namespace Demo.Demos.MarkdownToWord
                     InvisibleMathToSpace = false
                 },
                 _ => new CleaningOptions()
+            };
+        }
+
+        private static CleaningPreset GetPresetForSelectedCategory(InvisibleCharacterCategory category)
+        {
+            return category switch
+            {
+                InvisibleCharacterCategory.Confusables => CleaningPreset.Aggressive,
+                InvisibleCharacterCategory.NoBreakSpaces => CleaningPreset.Aggressive,
+                InvisibleCharacterCategory.ZeroWidthFormat => CleaningPreset.Aggressive,
+                InvisibleCharacterCategory.VariationSelectors => CleaningPreset.Aggressive,
+                InvisibleCharacterCategory.EmojiTags => CleaningPreset.Aggressive,
+                InvisibleCharacterCategory.CombiningMarks => CleaningPreset.Aggressive,
+                InvisibleCharacterCategory.Tab => CleaningPreset.Aggressive,
+                _ => CleaningPreset.Safe
             };
         }
     }


### PR DESCRIPTION
## Summary
- adjust selective cleaning to use aggressive cleaning actions when categories are explicitly selected
- add regression test ensuring the demo example is fully cleaned with all algorithms enabled

## Testing
- dotnet test Demo.sln

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692057f0656c832a8ff34e10b7bd3497)